### PR TITLE
Persona Definition

### DIFF
--- a/Tools/Personas.md
+++ b/Tools/Personas.md
@@ -18,7 +18,7 @@ Auch: Regulierer, Hersteller
 
 ### Beschreibung Provider
 
-Die Provider-Persona stellt anderen Nutzern (Auditoren, Automatisierern, Beratern) Quellinformationen zur Verfügung, auf deren Basis diese Ihre Tätigkeiten durchführen können.
+Die Provider-Persona stellt anderen Nutzern (Auditoren, Automatisierern, Beratern) Quellinformationen zur Verfügung, auf deren Basis diese ihre Tätigkeiten durchführen können.
 
 ### Usecases und Tools Provider
 


### PR DESCRIPTION
Auf Basis der Diskussion in #2 habe ich einen ersten Entwurf für die Personas gebaut.

Die Idee ist hierbei eine art "Katalog" anzufangen, in der die Verschiedenen Bedürfnisse der Personas aufgeführt sind (in meinem Fall als "Usecase") und die dafür identifizierten Tools aufzulisten. Dies soll als Einstiegshilfe für GS++ Involvierte dienen. 

Alle Auflistungen sind NICHT ABSCHLIEßEND. Heißt: Wir sollten Stück für Stück die Liste weiter ergänzen mit erkannten Lücken und fehlenden toolings. Ich habe versucht mich an der Liste https://github.com/Stand-der-Technik-Pro/Stand-der-Technik-Bibliothek/issues/2#issuecomment-3408209842 zu orientieren für die Erstbefüllung.

Was mir schon (negativ) aufgefallen ist, sind die Usecases teilweise doppelt sind, was die Pflege aufwändiger macht bei Änderungen. Ebenfalls kann die Tabellenstruktur irgendwann unübersichtlich werden. Alternative Idee wäre den Usecase jeweils an der Persona zu haben und die Tools für den Usecase separat in einer Usecase-Liste zu pflegen, ohne direkte Persona-Zuordung. Oder die Liste grundsätzlich umdrehen:


|Usecase|Tools|Personas|
|---|---|---|
|Konsumieren von Regulatorik (bspw. GS++ Katalog) als Basis für eigene Kataloge/Spezifizierungen|[HTML-Viewer](tbd), [OSCAL-Viewer](https://viewer.oscal.io/)|Provider, Automatisierer, Berater, Auditor|

Die Kür wäre natürlich irgendwann die Abbildung der Daten in einer maschinenlesbaren Datei, aus der man die verschiedenen Filter-Views sich dynamisch erzeugen lassen könnte. Aber ich denke, wir sollten da erstmal die Kirche im Dorf lassen 😄 

Was ebenfalls nützlich sein könnte wäre eine erweiterte Bewertung /Beschreibung der Toolings. Bspw. das der OSCAL-Viewer zwar alles schön valide listet, aber alles aufgeklappt werden muss.
Ebenfalls könnte man dort auch "Config-Tricks" hinterlegen oder verlinken wie beispielsweise die Einstellungen für utf-8 kompatibilität