### PR TITLE
Add GitHub Actions workflow for OSCAL validation

### DIFF
--- a/.github/workflows/oscal-cli-validate.yaml
+++ b/.github/workflows/oscal-cli-validate.yaml
@@ -1,0 +1,29 @@
+name: Validate OSCAL files
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        id: checkout
+      - name: Setup Java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: adopt
+          java-version: 11
+        id: setup_java
+      - name: Validate SSP schema and constraints (XML)
+        uses: oscal-club/oscal-cli-action@1a210b84bc1fd6adf15c9cf0d46a51d15a3d8301 # v2.0.1
+        with:
+          args: validate Kompendien/Grundschutz++-Kompendium/Grundschutz++-Kompendium.xml
+        id: validate_ssp_xml
+      - name: Validate SSP schema and constraints (JSON)
+        uses: oscal-club/oscal-cli-action@1a210b84bc1fd6adf15c9cf0d46a51d15a3d8301 # v2.0.1
+        with:
+          args: validate Kompendien/Grundschutz++-Kompendium/Grundschutz++-Kompendium.json
+        id: validate_ssp_json

--- a/.github/workflows/oscal-cli-validate.yaml
+++ b/.github/workflows/oscal-cli-validate.yaml
@@ -1,8 +1,6 @@
 name: Validate OSCAL files
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   validate:

--- a/.github/workflows/oscal-cli-validate.yaml
+++ b/.github/workflows/oscal-cli-validate.yaml
@@ -16,7 +16,7 @@ jobs:
           java-version: 11
         id: setup_java
       - name: Validate SSP schema and constraints (XML)
-        uses: oscal-club/oscal-cli-action@1a210b84bc1fd6adf15c9cf0d46a51d15a3d8301 # v2.0.1
+        uses: oscal-club/oscal-cli-action@b5b0c80a1a158797bea4475d13d12c494b56019b # v2.0.2
         with:
           args: validate Kompendien/Grundschutz++-Kompendium/Grundschutz++-Kompendium.xml
         id: validate_ssp_xml


### PR DESCRIPTION
Basierend auf https://github.com/BSI-Bund/Stand-der-Technik-Bibliothek/pull/21

Zu beachten ist der Umstand, dass anscheinend nicht die Quelldateien im Repo liegen, sondern bereits per oscal-cli generierte Artefakte: https://github.com/BSI-Bund/Stand-der-Technik-Bibliothek/issues/11

Idealerweise sollten diese aber auch nur bei Releases (via Git-Tag) als Dateien enthalten sein.
Somit kann es sein, dass die Workflow-Datei dann nochmal auf einen anderen Dateinamen umgestellt werden muss.

Ansonsten besteht das Risiko, dass aufgrund einer intransparenten Feedbackschleife die vorgeschlagenen Änderungen wie bei https://github.com/BSI-Bund/Stand-der-Technik-Bibliothek/pull/10#issuecomment-3370623190 manuell an anderer Stelle gepflegt werden und somit Aufwände multipliziert werden.

> Wir übernehmen die Vorschläge in unsere Quelldateien, sodass sie im nächsten Zyklus enthalten sind.

Verbesserungsvorschläge bezüglich eines transparenteren Prozesses sollten in Rücksprache mit BSI und der Editorenrunde auf Anwendbarkeit geprüft werden.